### PR TITLE
Improve update note only

### DIFF
--- a/lib/logaling/glossary.rb
+++ b/lib/logaling/glossary.rb
@@ -160,7 +160,13 @@ module Logaling
     end
 
     def bilingual_pair_exists_and_has_same_note?(glossary, source_term, target_term, note)
-      target_terms(glossary, source_term).any?{|data| data['target_term'] == target_term && data['note'] == note}
+      target_terms(glossary, source_term).any? do |data|
+        if note.empty?
+          data['target_term'] == target_term
+        else
+          data['target_term'] == target_term && data['note'] == note
+        end
+      end
     end
 
     def target_terms(glossary, source_term)

--- a/spec/logaling/glossary_spec.rb
+++ b/spec/logaling/glossary_spec.rb
@@ -89,7 +89,13 @@ module Logaling
         }
       end
 
-      context 'with note arguments show exisiting bilingual pair and note ' do
+      context 'with note arguments show exisiting bilingual pair' do
+        it {
+          -> { glossary.update("user", "ユーザ", "ユーザ", "") }.should raise_error(Logaling::TermError)
+        }
+      end
+
+      context 'with note arguments show exisiting bilingual pair and note' do
         it {
           -> { glossary.update("user", "ユーザ", "ユーザ", "ユーザーではない") }.should raise_error(Logaling::TermError)
         }


### PR DESCRIPTION
初めまして。

使っていて、元言語の用語と訳語は変えないまま、備考だけ変更したいということが何度かありました。
今は

```
$ loga delete original 訳語
$ loga add original 訳語 新しい備考
```

としているのですが、流石に億劫なのでパッチを書いてみました。
よければ取り込んでもらえると嬉しいです。
ご検討よろしくお願いします。
