### PR TITLE
fix separate-another-method-to-print-for-lookup

### DIFF
--- a/lib/logaling/command/application.rb
+++ b/lib/logaling/command/application.rb
@@ -30,7 +30,6 @@ module Logaling::Command
       @config = load_config_and_merge_options()
       @source_language = @config["source-language"]
       @target_language = @config["target-language"]
-      @glossary = glossary
     end
 
     map '-a' => :add,


### PR DESCRIPTION
.logaling/configがない状態でloga lookup 失敗する件、
修正したもの、pull requestします。すいません。
