### PR TITLE
Reduce duplication of Command#Application 

### DIFF
--- a/lib/logaling/command/application.rb
+++ b/lib/logaling/command/application.rb
@@ -272,7 +272,7 @@ module Logaling::Command
       end
     end
 
-    def load_config_and_merge_options(required={})
+    def load_config_and_merge_options
       config_list ||= {}
       find_config.each{|type, path| config_list[type] = load_config(path)}
       global_config = config_list["global_config"] ? config_list["global_config"] : {}
@@ -280,8 +280,6 @@ module Logaling::Command
 
       config = merge_options(project_config, global_config)
       config = merge_options(options, config)
-
-      check_required_option(config, required)
 
       config
     end


### PR DESCRIPTION
# load_config_and_merge_options が複数の箇所で呼ばれていて、その意図が
- #initializeでインスタンス変数にセットするために必ず呼ばれる(lookupの対応で入った)
- コマンドで設定値を参照したい場合に呼ばれる(必須項目のチェックもそこでまかなっている)
- #glossary をコールした段階で呼ばれる

だったので、以下のように整理してみました。
- 設定値はinitializeで設定されるインスタンス変数を参照する
- 必須項目のチェックをメソッドに切り出して、各コマンドではそれを使ってチェックを行う
