### PR TITLE
Use tmpdir as LOGALING_HOME when running specs

### DIFF
--- a/spec/logaling/command_spec.rb
+++ b/spec/logaling/command_spec.rb
@@ -18,7 +18,7 @@
 require File.join(File.dirname(__FILE__), "..", "spec_helper")
 
 describe Logaling::Command::Application do
-  let(:logaling_home) { LOGALING_HOME }
+  let(:logaling_home) { @logaling_home }
   let(:base_options) { {"glossary"=>"spec", "source-language"=>"en", "target-language"=>"ja"} }
   let(:command) { Logaling::Command::Application.new([], base_options) }
   let(:glossary_path) { Logaling::Glossary.build_path('spec', 'en', 'ja', logaling_home) }

--- a/spec/logaling/glossary_spec.rb
+++ b/spec/logaling/glossary_spec.rb
@@ -21,7 +21,7 @@ require "fileutils"
 module Logaling
   describe Glossary do
     let(:project) { "spec" }
-    let(:logaling_home) { LOGALING_HOME }
+    let(:logaling_home) { @logaling_home }
     let(:glossary) { Glossary.new(project, 'en', 'ja', logaling_home) }
     let(:glossary_path) { Glossary.build_path(project, 'en', 'ja', logaling_home) }
     let(:repository) { Logaling::Repository.new(logaling_home) }

--- a/spec/logaling/repository_spec.rb
+++ b/spec/logaling/repository_spec.rb
@@ -21,7 +21,7 @@ require "fileutils"
 module Logaling
   describe Repository do
     let(:project) { "spec" }
-    let(:logaling_home) { LOGALING_HOME }
+    let(:logaling_home) { @logaling_home }
     let(:glossary) { Glossary.new(project, 'en', 'ja', logaling_home) }
     let(:glossary_path) { Glossary.build_path(project, 'en', 'ja', logaling_home) }
     let(:repository) { Logaling::Repository.new(logaling_home) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,9 +17,8 @@ $LOAD_PATH.unshift(File.dirname(__FILE__) + '/../lib')
 require 'logaling'
 
 require "fileutils"
+require 'tmpdir'
 require 'stringio'
-
-LOGALING_HOME = File.expand_path("~/.logaling.d")
 
 RSpec.configure do |config|
   def capture(stream)
@@ -35,6 +34,17 @@ RSpec.configure do |config|
     result
   end
 
+  config.before(:suite) do
+    LOGALING_HOME = Dir.mktmpdir
+  end
+
+  config.before(:all) do
+    @logaling_home = LOGALING_HOME
+  end
+
+  config.after(:suite) do
+    FileUtils.remove_entry_secure(LOGALING_HOME, true)
+  end
+
   alias :silence :capture
 end
-


### PR DESCRIPTION
spec 実行時に ~/.logaling.d をさわらないようにしました！
