### PR TITLE
Move Glossary.build_path to instance method and rename

### DIFF
--- a/spec/logaling/command_spec.rb
+++ b/spec/logaling/command_spec.rb
@@ -22,7 +22,8 @@ describe Logaling::Command::Application do
   let(:logaling_config) { File.join(File.dirname(__FILE__), "..", "tmp", ".logaling") }
   let(:base_options) { {"glossary"=>"spec", "source-language"=>"en", "target-language"=>"ja", "logaling-config" => logaling_config} }
   let(:command) { Logaling::Command::Application.new([], base_options) }
-  let(:glossary_path) { Logaling::Glossary.build_path('spec', 'en', 'ja', logaling_home) }
+  let(:glossary) { Logaling::Glossary.new('spec', 'en', 'ja', logaling_home) }
+  let(:glossary_path) { glossary.source_path }
   let(:target_project_path) { File.join(logaling_home, "projects", "spec") }
   let(:repository) { Logaling::Repository.new(logaling_home) }
 

--- a/spec/logaling/glossary_spec.rb
+++ b/spec/logaling/glossary_spec.rb
@@ -23,7 +23,7 @@ module Logaling
     let(:project) { "spec" }
     let(:logaling_home) { @logaling_home }
     let(:glossary) { Glossary.new(project, 'en', 'ja', logaling_home) }
-    let(:glossary_path) { Glossary.build_path(project, 'en', 'ja', logaling_home) }
+    let(:glossary_path) { glossary.source_path }
     let(:repository) { Logaling::Repository.new(logaling_home) }
 
     before do

--- a/spec/logaling/repository_spec.rb
+++ b/spec/logaling/repository_spec.rb
@@ -23,7 +23,7 @@ module Logaling
     let(:project) { "spec" }
     let(:logaling_home) { @logaling_home }
     let(:glossary) { Glossary.new(project, 'en', 'ja', logaling_home) }
-    let(:glossary_path) { Glossary.build_path(project, 'en', 'ja', logaling_home) }
+    let(:glossary_path) { glossary.source_path }
     let(:repository) { Logaling::Repository.new(logaling_home) }
     let(:db_home) { File.join(logaling_home, "db") }
 


### PR DESCRIPTION
用語集のパスの決定を後ろにずらしておいた方が良いと考えたので、
Glossary.build_path を Glossary#source_path としてインスタンスメソッドに移動し、
またインスタンス生成時にはパスは決定しないようにしました。
