### PR TITLE
Add '--no-color' option to lookup command

### DIFF
--- a/lib/logaling/command/application.rb
+++ b/lib/logaling/command/application.rb
@@ -200,6 +200,7 @@ module Logaling::Command
     desc 'lookup [TERM]', 'Lookup terms.'
     method_option "output", type: :string, default: "terminal"
     method_option "no-pager", type: :boolean, default: false
+    method_option "no-color", type: :boolean, default: false
     method_option "dictionary", type: :boolean, default: false, aliases: "--dict"
     def lookup(source_term)
       @repository.index
@@ -344,7 +345,7 @@ module Logaling::Command
     end
 
     def extract_keyword_and_coloring(snipped_term, term)
-      return term if snipped_term.empty?
+      return term if snipped_term.empty? || options["no-color"]
       display_string = snipped_term.map do |word|
         word.is_a?(Hash) ? word[:keyword].bright : word
       end


### PR DESCRIPTION
logalimacs さんが使いやすいように、lookup の検索結果に色付けをさせない --no-color オプションを追加しました。
