### PR TITLE
Fix mozila empty entries

### DIFF
--- a/lib/logaling/external_glossaries/mozilla_japan.rb
+++ b/lib/logaling/external_glossaries/mozilla_japan.rb
@@ -32,7 +32,7 @@ module Logaling
       doc.css("dl[@class='terminology en-ja']").each do |dl|
         dl.children.each_slice(2) do |dt, dd|
           dd.text.split("|").each do |ddt|
-            ddt = ddt.gsub(/\s/, '')
+            ddt = ddt.gsub(/\s|\u{a0}/, '')
             unless ddt.empty?
               csv << [dust_to_tilda(dt.text), dust_to_tilda(ddt)]
             end


### PR DESCRIPTION
loga import mozilla_japan すると、訳語が空のエントリが複数登録されます。
# 原因

lib/logaling/external_glossaries/mozilla_japan.rb
において ddt に U+0020 が含まれており、これが除去されないのが原因でした。

`ddt.empty?` が `false` となり、スペースだけのエントリが登録されてしまいます。
# 対策

gsub にて U+0020 も除去するようにしました。
