### PR TITLE
Return [] if exception occures when trying to load empty yaml file

### DIFF
--- a/lib/logaling/glossary_sources/glossary_yaml_source.rb
+++ b/lib/logaling/glossary_sources/glossary_yaml_source.rb
@@ -29,7 +29,7 @@ module Logaling::GlossarySources
   class GlossaryYamlSource < Base
     def load
       YAML::load_file(source_path) || []
-    rescue
+    rescue TypeError
       []
     end
 


### PR DESCRIPTION
Ruby1.9.3-p194で空のyamlファイルをロードしようとするとexceptionが発生する件の修正です
