### PR TITLE
Split description and url on recipe of ExternalGlossary

### DIFF
--- a/lib/logaling/command/application.rb
+++ b/lib/logaling/command/application.rb
@@ -90,7 +90,7 @@ module Logaling::Command
       require "logaling/external_glossary"
       Logaling::ExternalGlossary.load
       if options["list"]
-        Logaling::ExternalGlossary.list.each {|glossary_source| say "#{glossary_source.name.bright} : #{glossary_source.description}" }
+        Logaling::ExternalGlossary.list.each {|glossary_source| say "#{glossary_source.name.bright} : #{glossary_source.description} (#{glossary_source.url})" }
       else
         case external_glossary
         when 'tmx'

--- a/lib/logaling/external_glossaries/debian_project.rb
+++ b/lib/logaling/external_glossaries/debian_project.rb
@@ -19,7 +19,8 @@ require 'nokogiri'
 
 module Logaling
   class DebianProject < ExternalGlossary
-    description     'Debian JP Project (http://www.debian.or.jp/community/translate/)'
+    description     'Debian JP Project'
+    url             'http://www.debian.or.jp/community/translate/'
     source_language 'en'
     target_language 'ja'
     output_format   'csv'

--- a/lib/logaling/external_glossaries/edict.rb
+++ b/lib/logaling/external_glossaries/edict.rb
@@ -19,7 +19,8 @@ require 'stringio'
 
 module Logaling
   class Edict < ExternalGlossary
-    description     'The EDICT Dictionary File (http://www.csse.monash.edu.au/~jwb/edict.html)'
+    description     'The EDICT Dictionary File'
+    url             'http://www.csse.monash.edu.au/~jwb/edict.html'
     source_language 'ja'
     target_language 'en'
     output_format   'csv'

--- a/lib/logaling/external_glossaries/freebsd_jpman.rb
+++ b/lib/logaling/external_glossaries/freebsd_jpman.rb
@@ -19,7 +19,8 @@ require 'open-uri'
 
 module Logaling
   class FreebsdJpman < ExternalGlossary
-    description     'FreeBSD jpman(http://www.jp.freebsd.org/man-jp/)'
+    description     'FreeBSD jpman'
+    url             'http://www.jp.freebsd.org/man-jp/'
     source_language 'en'
     target_language 'ja'
     output_format   'csv'

--- a/lib/logaling/external_glossaries/gene95.rb
+++ b/lib/logaling/external_glossaries/gene95.rb
@@ -21,7 +21,8 @@ require 'rubygems/package'
 
 module Logaling
   class Gene95 < ExternalGlossary
-    description     'GENE95 Dictionary (http://www.namazu.org/~tsuchiya/sdic/data/gene.html)'
+    description     'GENE95 Dictionary'
+    url             'http://www.namazu.org/~tsuchiya/sdic/data/gene.html'
     source_language 'en'
     target_language 'ja'
     output_format   'csv'

--- a/lib/logaling/external_glossaries/gnome_project.rb
+++ b/lib/logaling/external_glossaries/gnome_project.rb
@@ -19,7 +19,8 @@ require 'nokogiri'
 
 module Logaling
   class GnomeProject < ExternalGlossary
-    description     'GNOME Translation Project Ja (http://live.gnome.org/TranslationProjectJa)'
+    description     'GNOME Translation Project Ja'
+    url             'http://live.gnome.org/TranslationProjectJa'
     source_language 'en'
     target_language 'ja'
     output_format   'csv'

--- a/lib/logaling/external_glossaries/mozilla_japan.rb
+++ b/lib/logaling/external_glossaries/mozilla_japan.rb
@@ -17,7 +17,8 @@ require 'nokogiri'
 
 module Logaling
   class MozillaJapan < ExternalGlossary
-    description     'Mozilla Japan (http://www.mozilla-japan.org/jp/l10n/term/l10n.html)'
+    description     'Mozilla Japan'
+    url             'http://www.mozilla-japan.org/jp/l10n/term/l10n.html'
     source_language 'en'
     target_language 'ja'
     output_format   'csv'

--- a/lib/logaling/external_glossaries/postgresql_manual.rb
+++ b/lib/logaling/external_glossaries/postgresql_manual.rb
@@ -19,7 +19,8 @@ require 'nokogiri'
 
 module Logaling
   class PostgresqlManual < ExternalGlossary
-    description     'PostgreSQL7.1 Manual (http://osb.sraoss.co.jp/PostgreSQL/Manual/)'
+    description     'PostgreSQL7.1 Manual'
+    url             'http://osb.sraoss.co.jp/PostgreSQL/Manual/'
     source_language 'en'
     target_language 'ja'
     output_format   'csv'

--- a/lib/logaling/external_glossaries/tmx.rb
+++ b/lib/logaling/external_glossaries/tmx.rb
@@ -17,7 +17,8 @@ require 'open-uri'
 require 'nokogiri'
 module Logaling
   class Tmx < ExternalGlossary
-    description     'TMX 1.4b formatted glossary (http://www.gala-global.org/oscarStandards/tmx/)'
+    description     'TMX 1.4b formatted glossary'
+    url             'http://www.gala-global.org/oscarStandards/tmx/'
     source_language 'en'
     target_language 'ja'
     output_format   'csv'

--- a/lib/logaling/external_glossary.rb
+++ b/lib/logaling/external_glossary.rb
@@ -51,6 +51,10 @@ class Logaling::ExternalGlossary
       @description ||= val
     end
 
+    def url val=nil
+      @url ||= val
+    end
+
     def source_language val=nil
       @source_language ||= val
     end


### PR DESCRIPTION
外部用語集の定義ファイルの description 中にあった url を独立して記述するようにしました。
