### PR TITLE
Fix 'config' shortcut key

### DIFF
--- a/lib/logaling/command/application.rb
+++ b/lib/logaling/command/application.rb
@@ -55,7 +55,8 @@ module Logaling::Command
         '-L' => :list,
         '-s' => :show,
         '-v' => :version,
-        '-c' => :copy
+        '-c' => :config,
+        '-C' => :copy
 
     class_option "glossary",        type: :string, aliases: "-g"
     class_option "source-language", type: :string, aliases: "-S"


### PR DESCRIPTION
config -> -c
copy -> -C

because I think more 'config' than 'copy' is used on logaling-command.
this is associated with #79.
