### PR TITLE
Add Accept-Encoding header to a request for edict

### DIFF
--- a/lib/logaling/external_glossaries/edict.rb
+++ b/lib/logaling/external_glossaries/edict.rb
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require 'net/http'
+require 'open-uri'
 
 module Logaling
   class Edict < ExternalGlossary
@@ -27,21 +27,14 @@ module Logaling
     def convert_to_csv(csv)
       puts "downloading edict file..."
       url = 'http://ftp.monash.edu.au/pub/nihongo/edict.gz'
-      doc = Net::HTTP.get(URI.parse(url))
-      puts "importing edict file..."
-
-      lines = doc.each_line
-
-      lines.next # skip header
-
-      preprocessed_lines = lines.map do |line|
-        line.encode("UTF-8", "EUC-JP").chomp
-      end
-
-      preprocessed_lines.each do |line|
-        source, target = line.split('/', 2)
-        source = source.strip
-        csv << [source, target]
+      open(url) do |edict|
+        edict.gets # skip header
+        edict.each_line do |raw_line|
+          line = raw_line.encode("UTF-8", "EUC-JP").chomp
+          source, target = line.split('/', 2)
+          source = source.strip
+          csv << [source, target]
+        end
       end
     end
   end

--- a/lib/logaling/external_glossaries/edict.rb
+++ b/lib/logaling/external_glossaries/edict.rb
@@ -28,21 +28,21 @@ module Logaling
       puts "downloading edict file..."
       url = 'http://ftp.monash.edu.au/pub/nihongo/edict.gz'
       doc = Net::HTTP.get(URI.parse(url))
-        puts "importing edict file..."
+      puts "importing edict file..."
 
-        lines = doc.each_line
+      lines = doc.each_line
 
-        lines.next # skip header
+      lines.next # skip header
 
-        preprocessed_lines = lines.map do |line|
-          line.encode("UTF-8", "EUC-JP").chomp
-        end
+      preprocessed_lines = lines.map do |line|
+        line.encode("UTF-8", "EUC-JP").chomp
+      end
 
-        preprocessed_lines.each do |line|
-          source, target = line.split('/', 2)
-          source = source.strip
-          csv << [source, target]
-        end
+      preprocessed_lines.each do |line|
+        source, target = line.split('/', 2)
+        source = source.strip
+        csv << [source, target]
+      end
     end
   end
 end

--- a/lib/logaling/external_glossaries/edict.rb
+++ b/lib/logaling/external_glossaries/edict.rb
@@ -31,8 +31,9 @@ module Logaling
         edict.gets # skip header
         edict.each_line do |raw_line|
           line = raw_line.encode("UTF-8", "EUC-JP").chomp
-          source, target = line.split('/', 2)
-          source = source.strip
+          target, source = line.split('/', 2)
+          source.strip!
+          target.strip!
           csv << [source, target]
         end
       end

--- a/lib/logaling/external_glossaries/edict.rb
+++ b/lib/logaling/external_glossaries/edict.rb
@@ -13,9 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-require 'open-uri'
-require 'zlib'
-require 'stringio'
+require 'net/http'
 
 module Logaling
   class Edict < ExternalGlossary
@@ -29,10 +27,10 @@ module Logaling
     def convert_to_csv(csv)
       puts "downloading edict file..."
       url = 'http://ftp.monash.edu.au/pub/nihongo/edict.gz'
-      Zlib::GzipReader.open(open(url, { "Accept-Encoding" => "gzip, deflate" })) do |gz|
+      doc = Net::HTTP.get(URI.parse(url))
         puts "importing edict file..."
 
-        lines = StringIO.new(gz.read).each_line
+        lines = doc.each_line
 
         lines.next # skip header
 
@@ -45,7 +43,6 @@ module Logaling
           source = source.strip
           csv << [source, target]
         end
-      end
     end
   end
 end

--- a/lib/logaling/external_glossaries/edict.rb
+++ b/lib/logaling/external_glossaries/edict.rb
@@ -29,7 +29,7 @@ module Logaling
     def convert_to_csv(csv)
       puts "downloading edict file..."
       url = 'http://ftp.monash.edu.au/pub/nihongo/edict.gz'
-      Zlib::GzipReader.open(open(url)) do |gz|
+      Zlib::GzipReader.open(open(url, { "Accept-Encoding" => "gzip, deflate" })) do |gz|
         puts "importing edict file..."
 
         lines = StringIO.new(gz.read).each_line


### PR DESCRIPTION
Because, Server returns raw content when a client requests without header.

$ irb
irb(main):001:0> require 'zlib'
=> true
irb(main):002:0> require 'open-uri'
=> true
irb(main):003:0> url = 'http://ftp.monash.edu.au/pub/nihongo/edict.gz'
=> "http://ftp.monash.edu.au/pub/nihongo/edict.gz"
irb(main):004:0> Zlib::GzipReader.open(open(url))
Zlib::GzipFile::Error: not in gzip format
        from (irb):4:in `initialize'
        from (irb):4:in`open'
        from (irb):4
        from /usr/local/bin/irb:11:in `<main>'
irb(main):005:0> Zlib::GzipReader.open(open(url, { "Accept-Encoding" => "gzip, deflate" }))
=> #Zlib::GzipReader:0x007ff97ee5bf80
